### PR TITLE
added ajaxprefilter to script.js file to allow API call in github

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -16,6 +16,12 @@ var globalJobObject;
 var globalFavJobObject = [];
 var favoriteJobs = [];
 
+jQuery.ajaxPrefilter(function(options) {
+    if (options.crossDomain && jQuery.support.cors) {
+        options.url = 'https://cors-anywhere.herokuapp.com/' + options.url;
+    }
+}); 
+
 $.ajax({
     url: queryURL,
     method: "GET"


### PR DESCRIPTION
Hey Allen,

I added ajaxprefilter to script.js file that Andy gave us on Tuesday. This will allow us to run the Ajax call to the goremote.io api from Github without the CORS Chrome plugin.

That is the only change I made in this pull request. 